### PR TITLE
Migrate devcontainer to non-deprecated base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.11
+FROM mcr.microsoft.com/devcontainers/python:3.11-bookworm
 
 # Install required system packages
 RUN apt-get update \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
 				"ruff.path": [
-					"/usr/local/py-utils/bin/ruff"
+					"/usr/local/bin/ruff"
 				]
 			},
 			// Add the IDs of extensions you want installed when the container is created.

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,30 @@
+name: Dev Container Build Check
+
+on:
+  push:
+    paths:
+      - ".devcontainer/**"
+  pull_request:
+    paths:
+      - ".devcontainer/**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create .env file
+        run: cp .env.default .env
+
+      - name: Build Dev Container
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: devcontainer-build-check
+          push: never
+          configFile: .devcontainer/devcontainer.json

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -28,3 +28,5 @@ jobs:
           imageName: devcontainer-build-check
           push: never
           configFile: .devcontainer/devcontainer.json
+          cacheFrom: type=gha
+          cacheTo: type=gha,mode=max

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -28,5 +28,3 @@ jobs:
           imageName: devcontainer-build-check
           push: never
           configFile: .devcontainer/devcontainer.json
-          cacheFrom: type=gha
-          cacheTo: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Switches base image from deprecated `mcr.microsoft.com/vscode/devcontainers/python:0-3.11` (Debian 11) to `mcr.microsoft.com/devcontainers/python:3.11-bookworm` (Debian 12)
- Updates `ruff.path` in `devcontainer.json` from `/usr/local/py-utils/bin/ruff` to `/usr/local/bin/ruff` to match the new image's pipx bin directory
- Adds a GitHub Actions workflow to verify the devcontainer builds successfully on any changes to `.devcontainer/`

## Test plan
- [ ] Rebuild devcontainer and verify it starts successfully
- [ ] Verify ruff extension works in VS Code
- [ ] Verify pre-commit, poetry, and other pipx-installed tools are accessible
- [ ] Devcontainer build CI check passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)