### PR TITLE
Fix broken Streamlit badge and add pre-commit CI job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,16 +5,14 @@ on:
     branches: [main]
 
 jobs:
-  lint:
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install ruff
-      - run: ruff check .
-      - run: ruff format --check .
+      - uses: pre-commit/action@v3.0.1
 
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # :eyes: Googly eyes
-[![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://googly-eyes.streamlit.app/)
+[![Streamlit App](https://img.shields.io/badge/Streamlit-App-FF4B4B?logo=streamlit&logoColor=white)](https://googly-eyes.streamlit.app/)
 
 The objective of this project is to be able to:
 1. Detect faces in an image


### PR DESCRIPTION
## Summary
- Replace broken `static.streamlit.io` badge URL (returns 403) with an equivalent shields.io badge
- Replace manual `ruff` lint steps in CI with the official `pre-commit/action`, which runs all hooks (ruff + typos) with built-in env caching

## Test plan
- [x] Verify badge renders correctly in README preview
- [x] Verify `pre-commit` CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)