### PR TITLE
Fix Lambda crash on RGBA PNG input

### DIFF
--- a/common/drawing.py
+++ b/common/drawing.py
@@ -20,15 +20,15 @@ def add_googly_eyes(image: Image, face: Face, eye_size: float, pupil_size_range:
             draw,
             eye,
             radius=eye_size * radius,
-            fill=(255, 255, 255, 0),
-            outline=(0, 0, 0, 0),
+            fill=(255, 255, 255, 255),
+            outline=(0, 0, 0, 255),
         )
         orientation = np.random.uniform(0, np.pi)
         plot_circle(
             draw,
             np.array(eye) + (eye_size - pupil_size) * radius * np.array([np.sin(orientation), np.cos(orientation)]),
             radius=pupil_size * radius,
-            fill=(0, 0, 0, 0),
+            fill=(0, 0, 0, 255),
         )
 
     plot_googly_eye(face.landmarks["right_eye"])

--- a/retinaface/commons/preprocess.py
+++ b/retinaface/commons/preprocess.py
@@ -38,6 +38,10 @@ def get_image(img_uri: str | np.ndarray) -> np.ndarray:
     if len(img.shape) != 3 or np.prod(img.shape) == 0:
         raise ValueError("Input image needs to have 3 channels at must not be empty.")
 
+    # Strip alpha channel if present (e.g. RGBA PNGs)
+    if img.shape[2] == 4:
+        img = img[:, :, :3]
+
     return img
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -27,6 +27,13 @@ def _make_png_image() -> Image.Image:
     return Image.open(buf)
 
 
+def _make_rgba_png_image() -> Image.Image:
+    buf = BytesIO()
+    Image.new("RGBA", (20, 20), color=(10, 20, 30, 128)).save(buf, format="PNG")
+    buf.seek(0)
+    return Image.open(buf)
+
+
 class TestGetImageFromBytes:
     def test_returns_pil_image(self):
         buf = BytesIO()
@@ -92,6 +99,16 @@ class TestSerializeDeserialize:
         img = _make_png_image()
         recovered = deserialize_image(serialize_image(img))
         np.testing.assert_array_equal(np.array(recovered), np.array(img))
+
+    def test_roundtrip_preserves_rgba_mode(self):
+        img = _make_rgba_png_image()
+        recovered = deserialize_image(serialize_image(img))
+        assert recovered.mode == "RGBA"
+
+    def test_rgb_roundtrip_does_not_gain_alpha(self):
+        img = _make_png_image()
+        recovered = deserialize_image(serialize_image(img))
+        assert recovered.mode == "RGB"
 
     def test_deserialize_invalid_base64_raises(self):
         with pytest.raises(Exception):

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -28,6 +28,12 @@ class TestGetImage:
         with pytest.raises(ValueError):
             get_image(12345)  # type: ignore[arg-type]
 
+    def test_rgba_stripped_to_rgb(self):
+        img = np.full((50, 60, 4), fill_value=128, dtype=np.uint8)
+        result = get_image(img)
+        assert result.shape[2] == 3
+        np.testing.assert_array_equal(result, img[:, :, :3])
+
 
 class TestResizeImage:
     def test_output_is_target_size(self):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -18,9 +18,11 @@ from PIL import Image
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lambda"))
 
 
-def _make_payload(width: int = 100, height: int = 100) -> dict:
+def _make_payload(width: int = 100, height: int = 100, mode: str = "RGB") -> dict:
     buf = BytesIO()
-    Image.new("RGB", (width, height), color=(200, 200, 200)).save(buf, format="JPEG")
+    fmt = "PNG" if mode == "RGBA" else "JPEG"
+    color = (200, 200, 200, 128) if mode == "RGBA" else (200, 200, 200)
+    Image.new(mode, (width, height), color=color).save(buf, format=fmt)
     buf.seek(0)
     import base64
 
@@ -82,6 +84,26 @@ class TestLambdaSmoke:
             result = predict.lambda_handler({"body": json.dumps(payload)}, None)
 
         assert "image" in result
+
+    def test_rgba_input_preserves_alpha_in_output(self):
+        import predict
+
+        with patch("common.googlify.detect_faces", return_value=[]):
+            result = predict.lambda_handler({"body": json.dumps(_make_payload(mode="RGBA"))}, None)
+
+        from common.image import deserialize_image
+
+        assert deserialize_image(result["image"]).mode == "RGBA"
+
+    def test_rgb_input_does_not_gain_alpha(self):
+        import predict
+
+        with patch("common.googlify.detect_faces", return_value=[]):
+            result = predict.lambda_handler({"body": json.dumps(_make_payload(mode="RGB"))}, None)
+
+        from common.image import deserialize_image
+
+        assert deserialize_image(result["image"]).mode == "RGB"
 
     def test_response_image_differs_from_input_when_face_detected(self):
         import predict


### PR DESCRIPTION
## Summary
- RGBA PNGs caused a `RuntimeError` in the Lambda: TFLite received a `[1,1024,1024,4]` tensor but BatchNorm expected 3 channels. Strip alpha in `preprocess.py` before feeding to the model.
- Drawing fill colours had `alpha=0`, making googly eyes invisible on RGBA images. Fixed to `alpha=255` (opaque).

Input/output image mode is preserved: RGB in → RGB out, RGBA in → RGBA out.

## Test plan
- [x] Send a JPEG — works as before, no alpha added
- [x] Send an RGBA PNG — no longer crashes, eyes are visible, alpha preserved in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)